### PR TITLE
feat: 이메일 인증 기능 및 인증 링크 전송 로직 구현

### DIFF
--- a/beanBa/src/main/java/likelion/beanBa/backendProject/member/auth/controller/AuthController.java
+++ b/beanBa/src/main/java/likelion/beanBa/backendProject/member/auth/controller/AuthController.java
@@ -6,9 +6,15 @@ import likelion.beanBa.backendProject.member.auth.dto.LoginRequest;
 import likelion.beanBa.backendProject.member.auth.dto.LoginResponse;
 import likelion.beanBa.backendProject.member.auth.dto.RefreshTokenRequest;
 import likelion.beanBa.backendProject.member.auth.service.AuthService;
+import likelion.beanBa.backendProject.member.dto.SignupRequest;
+import likelion.beanBa.backendProject.member.email.service.EmailAuthService;
+import likelion.beanBa.backendProject.member.email.service.EmailService;
+import likelion.beanBa.backendProject.member.repository.MemberRepository;
 import likelion.beanBa.backendProject.member.security.annotation.CurrentUser;
 import likelion.beanBa.backendProject.member.security.service.CustomUserDetails;
+import likelion.beanBa.backendProject.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,13 +23,53 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final MemberService memberService;
     private final AuthService authService;
+    private final EmailService emailService;
+    private final EmailAuthService emailAuthService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
             @RequestBody @Valid LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(
+            @RequestBody SignupRequest request) {
+
+        if(!emailAuthService.isEmailVerified(request.getEmail())){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("이메일 인증을 먼저 진행해주세요.");
+        }
+
+        memberService.signup(request);
+        emailAuthService.clearVerified(request.getEmail());
+        return ResponseEntity.ok("회원 가입 완료.");
+    }
+
+    @PostMapping("/signup/email")
+    public ResponseEntity<String> sendEmailVerification(
+            @RequestParam String email) {
+        if(memberRepository.existsByEmail(email)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 가입된 이메일 입니다.");
+        }
+        emailService.sendVerificationCode(email);
+        return ResponseEntity.ok("이메일 인증 메일을 전송했습니다.");
+    }
+
+    @GetMapping("/signup/verify")
+    public ResponseEntity<String> emailVerify(
+            @RequestParam String email,
+            @RequestParam String token) {
+        boolean verified = emailService.verifyCode(email, token);
+        if(verified) {
+            emailAuthService.markEmailAsVerified(email);
+            return ResponseEntity.ok("이메일 인증 성공");
+        } else {
+            return ResponseEntity.badRequest().body("이메일 인증 실패");
+        }
     }
 
     @PostMapping("/refresh")

--- a/beanBa/src/main/java/likelion/beanBa/backendProject/member/controller/MemberController.java
+++ b/beanBa/src/main/java/likelion/beanBa/backendProject/member/controller/MemberController.java
@@ -1,9 +1,7 @@
 package likelion.beanBa.backendProject.member.controller;
 
-import jakarta.validation.Valid;
 import likelion.beanBa.backendProject.member.dto.MemberRequest;
 import likelion.beanBa.backendProject.member.dto.MemberResponse;
-import likelion.beanBa.backendProject.member.dto.SignupRequest;
 import likelion.beanBa.backendProject.member.Entity.Member;
 import likelion.beanBa.backendProject.member.security.annotation.CurrentUser;
 import likelion.beanBa.backendProject.member.security.service.CustomUserDetails;
@@ -32,14 +30,6 @@ public class MemberController {
             @RequestBody MemberRequest request) {
         Long memberPk = userDetails.getMember().getMemberPk();
         return ResponseEntity.ok(memberService.updateMember(memberPk, request));
-    }
-
-
-    @PostMapping("/signup")
-    public ResponseEntity<String> signup(
-            @RequestBody @Valid SignupRequest request) {
-        memberService.signup(request);
-        return ResponseEntity.ok("회원 가입 완료.");
     }
 
     @DeleteMapping("/deleteMember")

--- a/beanBa/src/main/java/likelion/beanBa/backendProject/member/email/service/EmailAuthService.java
+++ b/beanBa/src/main/java/likelion/beanBa/backendProject/member/email/service/EmailAuthService.java
@@ -1,0 +1,25 @@
+package likelion.beanBa.backendProject.member.email.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class EmailAuthService {
+
+    private final Set<String> verifiedEmails = ConcurrentHashMap.newKeySet();
+
+    public void markEmailAsVerified(String email) {
+        verifiedEmails.add(email);
+    }
+
+    public boolean isEmailVerified(String email){
+        return verifiedEmails.contains(email);
+    }
+
+    public void clearVerified(String email) {
+        verifiedEmails.remove(email);
+    }
+
+}

--- a/beanBa/src/main/java/likelion/beanBa/backendProject/member/email/service/EmailService.java
+++ b/beanBa/src/main/java/likelion/beanBa/backendProject/member/email/service/EmailService.java
@@ -15,26 +15,31 @@ public class EmailService {
 
     private final JavaMailSender javaMailSender;
     private final JwtTokenProvider jwtTokenProvider;
-
     private final Map<String, String> emailCodeMap = new ConcurrentHashMap<>();
 
     public void sendVerificationCode(String email) {
         String token = jwtTokenProvider.generateEmailToken(email);
+        email = email.trim().toLowerCase();
         emailCodeMap.put(email, token);
 
         SimpleMailMessage message = new SimpleMailMessage();
 
         message.setTo(email);
         message.setSubject("콩바구니 회원가입 이메일 인증");
-        message.setText("인증 토큰 : "+token);
+        String verifyUrl = "https://localhost:8080/signup/verify?email=" + email + "&token=" + token;
+        message.setText("콩바구니 회원가입을 위해 아래 링크를 클릭해주세요:\n" + verifyUrl);
 
         javaMailSender.send(message);
     }
 
     public boolean verifyCode(String email, String token) {
+        email = email.trim().toLowerCase();
         String storedToken = emailCodeMap.get(email);
         if(storedToken == null || !storedToken.equals(token)) return false;
-        return jwtTokenProvider.validateToken(token) &&
-                jwtTokenProvider.getMemberIdFromToken(token).equals(email);
+        if(!jwtTokenProvider.validateToken(token)) return false;
+        if(!jwtTokenProvider.getMemberIdFromToken(token).equals(email)) return false;
+
+        emailCodeMap.remove(email);
+        return true;
     }
 }

--- a/beanBa/src/main/java/likelion/beanBa/backendProject/member/security/config/SecurityConfig.java
+++ b/beanBa/src/main/java/likelion/beanBa/backendProject/member/security/config/SecurityConfig.java
@@ -43,9 +43,9 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(
-                        "/api/member/signup",
                         "/api/auth/login",
                         "/api/auth/refresh",
+                        "/api/auth/signup/**",
                         "/oauth2/**",
                         "/upload",
                         "/swagger-ui/**",


### PR DESCRIPTION
- EmailService에서 JWT 기반 인증 토큰 생성 및 이메일 발송
- 이메일 인증 링크 클릭 시 자동 검증 처리 (/signup/verify)
- EmailAuthService에서 인증 상태 저장 및 확인 기능 분리
- 중복 가입 방지 및 토큰 재사용 방지 로직 추가
- 이메일 파라미터 중복 전달 이슈 대응(split + 정제 처리)